### PR TITLE
bug :: 63 add proguard rules to keep serialized annotated members

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,9 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Keeps the SerializedName annotations on all fields in all classes.
+# This is necessary for using the Gson library to serialize and deserialize objects.
+-keepclassmembers,allowobfuscation class * {
+ @com.google.gson.annotations.SerializedName <fields>;
+}


### PR DESCRIPTION
Fixes #63 

Add proguard rules in app level to keep annotated class members.
R8 strips annotated members of DTO - could be fixed in concrete DTO - MarketChartDto with @Keep annotation, but issue could happen with other DTOs as well 